### PR TITLE
Replace GH_NPM_PACKAGE_READ_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ registries:
   npm-github:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: ${{secrets.GH_NPM_PACKAGE_READ_TOKEN}}
+    token: ${{secrets.GITHUB_TOKEN}}
 
 updates:
   # Maintain dependencies for GitHub Actions

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - run: npm install
         env:
-          GITHUB_NPM_TOKEN: ${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}
+          GITHUB_NPM_TOKEN: ${{ github.token }}
 
       - run: npm run build
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      packages: read
       id-token: "write"
       contents: "read"
 


### PR DESCRIPTION
## Summary
- Replaces `GH_NPM_PACKAGE_READ_TOKEN` PAT with native `GITHUB_TOKEN` for npm package access
- Private `@zuplo/*` packages now grant Actions access to consuming repos directly via GitHub's package permissions

## Changes
- **Workflow files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ github.token }}`
- **Dependabot files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ secrets.GITHUB_TOKEN }}`

## Test plan
- [ ] CI passes with the new token configuration
- [ ] Private `@zuplo/*` packages install successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)