### PR TITLE
Modify TypeScript configuration for ESNext and ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,22 +2,18 @@
   "include": ["modules/**/*", ".zuplo/**/*", "tests/**/*"],
   "exclude": ["./node_modules", "./dist"],
   "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "./dist",
-    "module": "commonjs",
-    "target": "ESNext",
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ESNext", "WebWorker", "Webworker.Iterable"],
     "preserveConstEnums": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "removeComments": true,
     "esModuleInterop": true,
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
+    "noEmit": true,
     "strictNullChecks": true,
-    "experimentalDecorators": true,
-    "resolveJsonModule": true
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
Updated TypeScript compiler options to use ESNext module and ES2022 target. Changed module resolution strategy to Bundler and added new lib options.